### PR TITLE
refs platform/#2764: fix the parent for the Artifact Registry repository tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2024-12-16
+
+[Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-project-resources-tags-helper/compare/0.2.0...0.2.1)
+
+### Changes
+
+- Fix the `parent` for the Artifact Registry tags.
+
 ## [0.2.0] - 2024-04-02
 
 [Compare with previous version](https://github.com/sparkfabrik/terraform-google-gcp-project-resources-tags-helper/compare/0.1.0...0.2.0)
 
 ### Added
 
-- Add support for Artifact Registry tags
+- Add support for Artifact Registry tags.
 
 ## [0.1.0] - 2023-08-04
 

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,10 @@ data "google_tags_tag_value" "project_tag_values_to_be_discovered" {
   short_name = each.value.tag_value_shortname
 }
 
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
 # ---------------------------------
 # Binding Google Tags to resources
 # ---------------------------------
@@ -159,7 +163,9 @@ resource "google_tags_location_tag_binding" "cloudsql" {
 resource "google_tags_location_tag_binding" "artifact_registry" {
   for_each = local.map_of_artifact_registry_repositories_to_be_tagged
   # Parent full resource name reference: https://cloud.google.com/artifact-registry/docs/repositories/tag-repos#attach
-  parent    = "//artifactregistry.googleapis.com/projects/${var.project_id}/locations/${each.value.repository_location}/repositories/${each.value.repository_id}"
+  # For the Artifact Registry, the parent needs to be in the form:
+  # //artifactregistry.googleapis.com/projects/PROJECT_NUMBER/locations/LOCATION/repositories/REPOSITORY_ID
+  parent    = "//artifactregistry.googleapis.com/projects/${data.google_project.project.number}/locations/${each.value.repository_location}/repositories/${each.value.repository_id}"
   location  = each.value.repository_location
   tag_value = data.google_tags_tag_value.tag_values[each.value.tag_friendly_name].id
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the parent format for Artifact Registry repository tagging by using project number instead of project ID
- Added `google_project` data source to fetch project number from project ID
- Updated CHANGELOG.md to document the fix in version 0.2.1



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Fix Artifact Registry tag binding parent format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Added data source to fetch project number from project ID<br> <li> Updated Artifact Registry tag binding parent format to use project <br>number instead of project ID<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-project-resources-tags-helper/pull/6/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with Artifact Registry fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added entry for version 0.2.1 documenting the Artifact Registry parent <br>fix<br> <li> Minor formatting improvements<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-google-gcp-project-resources-tags-helper/pull/6/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information